### PR TITLE
add support for richtext checkbox

### DIFF
--- a/wagtail_advanced_form_builder/templates/wagtail_advanced_form_builder/fields/richtext_checkbox_field.html
+++ b/wagtail_advanced_form_builder/templates/wagtail_advanced_form_builder/fields/richtext_checkbox_field.html
@@ -1,0 +1,16 @@
+{# NB: 'RichTextCheckboxInput' is defined in the EL code because it needs access to the simple rich text block #}
+<div
+        class="waf--field-container {% if field.errors %}waf--field-container--error{% endif %}"
+        data-waf-field
+>
+    <div class="waf--checkbox-container">
+        {{ field }}
+        <label class="waf--field-label-choice" for="{{ field.id_for_label }}">
+            {{ field.field.widget.attrs.display_text|safe }}
+        </label>
+    </div>
+    {% if field.help_text %}
+        {% include "wagtail_advanced_form_builder/field_helpers/field_help_text.html" %}
+    {% endif %}
+    {% include "wagtail_advanced_form_builder/field_helpers/field_error.html" %}
+</div>

--- a/wagtail_advanced_form_builder/templates/wagtail_advanced_form_builder/tags/form_field.html
+++ b/wagtail_advanced_form_builder/templates/wagtail_advanced_form_builder/tags/form_field.html
@@ -20,6 +20,9 @@
     {% include "wagtail_advanced_form_builder/fields/text_area_field.html" with field=field %}
 {% elif field|fieldtype == 'FieldToggleInput' %}
     {% include "wagtail_advanced_form_builder/fields/field_toggle.html" with field=field %}
+{% elif field|fieldtype == 'RichTextCheckboxInput' %}
+    {# NB: 'RichTextCheckboxInput' is defined in the EL code because it needs access to the simple rich text block #}
+    {% include "wagtail_advanced_form_builder/fields/richtext_checkbox_field.html" with field=field %}
 {% else %}
     {% include "wagtail_advanced_form_builder/fields/default_field.html" with field=field %}
 {% endif %}


### PR DESCRIPTION
Adds form field support for a `RichTextCheckboxInput` that allows a checkbox that has a simple rich text field as the label. This is pretty non-standard because the actual definition of `RichTextCheckboxInput` resides in the EL codebase. This is due to the fact that the `display_text` field needs to be a simple rich text block, which is defined in EL.