### PR TITLE
fix unhandled blank / null variable in form editor preview

### DIFF
--- a/wagtail_advanced_form_builder/blocks/fields/multi_line_field_block.py
+++ b/wagtail_advanced_form_builder/blocks/fields/multi_line_field_block.py
@@ -20,5 +20,5 @@ class MultiLineFieldBlock(BaseFieldBlock):
     placeholder = None
 
     class Meta:
-        form_classname = "waf--field"
+        form_classname = "waf--field form-control"
         icon = "extraicons--text-box"

--- a/wagtail_advanced_form_builder/blocks/fields/single_line_field_block.py
+++ b/wagtail_advanced_form_builder/blocks/fields/single_line_field_block.py
@@ -15,5 +15,5 @@ class SingleLineFieldBlock(BaseFieldBlock):
 
     class Meta:
 
-        form_classname = 'waf--field'
+        form_classname = 'waf--field form-control'
         icon = 'extraicons--basic-field'

--- a/wagtail_advanced_form_builder/blocks/fields/single_line_field_block.py
+++ b/wagtail_advanced_form_builder/blocks/fields/single_line_field_block.py
@@ -15,5 +15,5 @@ class SingleLineFieldBlock(BaseFieldBlock):
 
     class Meta:
 
-        form_classname = 'waf--field form-control'
+        form_classname = 'waf--field'
         icon = 'extraicons--basic-field'

--- a/wagtail_advanced_form_builder/templates/wagtail_advanced_form_builder/form/form_builder.html
+++ b/wagtail_advanced_form_builder/templates/wagtail_advanced_form_builder/form/form_builder.html
@@ -1,7 +1,9 @@
 {% include "wagtail_advanced_form_builder/form/no_script_notification.html" %}
 
 <script>
-    window.wafFormConditions = {{ conditional_rules|safe }};
+    {% if conditional_rules %}
+        window.wafFormConditions = {{ conditional_rules|safe }};
+    {% endif %)
     {% if stop_conditions %}
         window.wafStopConditions = {{ stop_conditions|safe }};
     {% endif %}


### PR DESCRIPTION
Heya, you seem to be the only one working on this form builder, which is pretty nice so now there's two of us!

Trying to fix the preview of the form in the admin UI on Wagtail 6.xx, starting with this unhandled blank / null / missing variable declaration in the template.

![image](https://github.com/user-attachments/assets/672386cc-1231-463c-bc88-d9ed3042e3d9)
